### PR TITLE
Fixing break of docker build on non existing composer.lock-file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ WORKDIR /srv/sylius
 ARG APP_ENV=prod
 
 # prevent the reinstallation of vendors at every changes in the source code
-COPY composer.json composer.lock symfony.lock ./
+COPY composer.json composer.loc* symfony.lock ./
 RUN set -eux; \
 	composer install --prefer-dist --no-autoloader --no-scripts --no-progress --no-suggest; \
 	composer clear-cache


### PR DESCRIPTION
After a fresh clone from git-repository, any `docker-compose up` will fail due to the non-existing of the file `composer.lock` at this stage.

This fix makes the COPY-command resistant against this issue and will copy the file only if it exists but does not abort if it doesn't.